### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 netCDF4
-xlrd
+openpyxl


### PR DESCRIPTION
Swapped openpyxl for xlrd after following error message: Your version of xlrd is 2.0.1. In xlrd >= 2.0, only the xls format is supported. Install openpyxl instead.